### PR TITLE
Refine docker cleanup check

### DIFF
--- a/arrstack.sh
+++ b/arrstack.sh
@@ -238,7 +238,13 @@ purge_native_packages() {
 }
 final_docker_cleanup() {
   step "5/12 Final Docker cleanup pass"
-  for CONTAINER in ${ALL_CONTAINERS}; do if docker ps -aq --filter "name=${CONTAINER}" | grep -q .; then run_cmd docker rm -f $(docker ps -aq --filter "name=${CONTAINER}") >/dev/null 2>&1 || true; else note "No leftover ${CONTAINER}"; fi; done
+  for CONTAINER in ${ALL_CONTAINERS}; do
+    if docker ps -aq --filter "name=${CONTAINER}" | grep -q .; then
+      run_cmd docker rm -f "$(docker ps -aq --filter "name=${CONTAINER}")" >/dev/null 2>&1 || true
+    else
+      note "No leftover ${CONTAINER}"
+    fi
+  done
   ok "Docker containers cleaned"
 }
 


### PR DESCRIPTION
## Summary
- improve Docker cleanup to explicitly check for leftover containers before removal

## Testing
- `bash -n arrstack.sh`
- `shellcheck arrstack.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c4e2a5b490832986cf9609c40dfa24