### PR TITLE
Separate src declaration and assignment

### DIFF
--- a/arrstack.sh
+++ b/arrstack.sh
@@ -646,7 +646,8 @@ start_with_checks() {
 
 install_aliases() {
   step "Installing ARR helper aliases"
-  local src="$(dirname "${BASH_SOURCE[0]}")/.aliasarr"
+  local src
+  src="$(dirname "${BASH_SOURCE[0]}")/.aliasarr"
   local dst="${ARR_STACK_DIR}/.aliasarr"
   run_cmd cp "$src" "$dst"
   local shellrc="/home/${USER_NAME}/.zshrc"


### PR DESCRIPTION
## Summary
- split src variable declaration and assignment in arrstack alias installer for readability

## Testing
- `bash -n arrstack.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c4e2cd475483298d44a9c503d20c6a