### PR TITLE
Handle Proton credential input without losing characters

### DIFF
--- a/arrstack.sh
+++ b/arrstack.sh
@@ -264,9 +264,9 @@ ensure_creds_template() {
   fi
   if ! grep -q '^PROTON_USER=' "${PROTON_CREDS_FILE}" || ! grep -q '^PROTON_PASS=' "${PROTON_CREDS_FILE}"; then
     local user pass
-    read -p "Proton username (without +pmp): " user
-    read -s -p "Proton password: " pass
-    echo
+    IFS= read -r -p "Proton username (without +pmp): " user
+    IFS= read -r -s -p "Proton password: " pass
+    printf '\n'
     sed -i '/^PROTON_USER=/d;/^PROTON_PASS=/d' "${PROTON_CREDS_FILE}"
     echo "PROTON_USER=${user}" >>"${PROTON_CREDS_FILE}"
     echo "PROTON_PASS=${pass}" >>"${PROTON_CREDS_FILE}"


### PR DESCRIPTION
## Summary
- Preserve all characters in Proton credential prompts by using `IFS= read -r`
- Restore terminal newline after hidden password entry with `printf '\n'`

## Testing
- `bash -n arrstack.sh`
- `shellcheck arrstack.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e2ad809c83299a8ca02b22ee2a76