### PR TITLE
feat: add overridable user config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ docker/
 arrconf/*
 !arrconf/README.md
 !arrconf/.gitkeep
+!arrconf/userconf.sh

--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ By default the stack connects with **OpenVPN** for reliable port forwarding; **W
 
 2. **Review and customise configuration:**
 
-   * Open `arrstack.sh` and adjust the variables in the `USER CONFIG` section.
+   * Defaults live in the `USER CONFIG` section of `arrstack.sh`. To keep the installer clean, override any of these settings in `arrconf/userconf.sh` by uncommenting the lines you need; the file is sourced on every run so you can adjust it before the first install or later and rerun the script.
    * Common tweaks: `LAN_IP`, download/media paths, qBittorrent credentials (`QBT_USER`/`QBT_PASS`), `QBT_WEBUI_PORT` (single source for the WebUI port), `GLUETUN_CONTROL_HOST`, `TIMEZONE`, and Proton server options (`SERVER_COUNTRIES`, `DEFAULT_VPN_MODE`).
 
    ```bash
-   nano arrstack.sh             # edit configuration
+   nano arrconf/userconf.sh     # uncomment overrides
+   nano arrstack.sh             # view all defaults
    nano arrstack-uninstall.sh   # optional reset script
    ```
 

--- a/arrconf/README.md
+++ b/arrconf/README.md
@@ -4,5 +4,6 @@ This directory stores ProtonVPN credentials and optional WireGuard profiles.
 
 - `proton.auth` – two lines `PROTON_USER=...` and `PROTON_PASS=...` (no `+pmp`).
 - `wg*.conf` – Proton WireGuard configuration files.
+- `userconf.sh` – uncomment settings to override defaults in `arrstack.sh`.
 
 Keep this folder at `700` and files at `600` to protect secrets.

--- a/arrconf/userconf.sh
+++ b/arrconf/userconf.sh
@@ -1,0 +1,67 @@
+# shellcheck shell=bash
+# Optional user overrides for arrstack.
+# Uncomment and edit settings below to override defaults from arrstack.sh.
+
+# USER_NAME="${USER:-$(id -un)}"
+# ARR_BASE="/home/${USER_NAME}/srv"
+# ARR_DOCKER_DIR="${ARR_BASE}/docker"
+# ARR_STACK_DIR="${ARR_BASE}/arrstack"
+# ARR_BACKUP_DIR="${ARR_BASE}/backups"
+# ARRCONF_DIR="${REPO_ROOT}/arrconf"
+
+# Legacy secrets paths (auto-migrated on first run)
+# LEGACY_VPNCONFS_DIR="${ARR_BASE}/wg-configs"     # legacy Proton WG config directory
+# LEGACY_CREDS_DOCKER="${ARR_DOCKER_DIR}/gluetun/proton-credentials.conf" # legacy OpenVPN creds
+# LEGACY_CREDS_WG="${LEGACY_VPNCONFS_DIR}/proton-credentials.conf"         # legacy WG creds
+
+# Local IP for binding services
+# LAN_IP="192.168.1.50" # set to your host's LAN IP
+# GLUETUN_CONTROL_PORT="8000" # Gluetun control server port
+# GLUETUN_CONTROL_HOST="127.0.0.1" # Host used for Gluetun control server checks
+
+# Media/Downloads layout
+# MEDIA_DIR="/media/mediasmb"
+# DOWNLOADS_DIR="/home/${USER_NAME}/downloads"
+# COMPLETED_DIR="${DOWNLOADS_DIR}/completed"
+# MOVIES_DIR="${MEDIA_DIR}/Movies"
+# TV_DIR="${MEDIA_DIR}/Shows"
+# SUBS_DIR="${MEDIA_DIR}/subs"
+
+# qBittorrent UI credentials/ports
+# QBT_WEBUI_PORT="8080"     # qBittorrent WebUI port inside container
+# QBT_HTTP_PORT_HOST="8080" # host port mapped to qBittorrent
+# QBT_USER=""
+# QBT_PASS=""
+# GLUETUN_API_KEY=""
+
+# Service ports (host:container)
+# SONARR_PORT="8989"
+# RADARR_PORT="7878"
+# PROWLARR_PORT="9696"
+# BAZARR_PORT="6767"
+# FLARESOLVERR_PORT="8191"
+
+# Identity & timezone
+# PUID="$(id -u)"
+# PGID="$(id -g)"
+# TIMEZONE="Australia/Sydney"
+
+# Proton defaults and selection
+# PROTON_AUTH_FILE="${ARRCONF_DIR}/proton.auth"
+# DEFAULT_VPN_MODE="openvpn" # openvpn (preferred) | wireguard (fallback)
+# SERVER_COUNTRIES="Netherlands,Germany,Switzerland,Australia,Spain,United States"
+# DEFAULT_COUNTRY="Australia"
+
+# Service/package lists (kept at least as broad as originals)
+# ALL_CONTAINERS="gluetun qbittorrent sonarr radarr prowlarr bazarr flaresolverr jackett transmission lidarr readarr"
+# ALL_NATIVE_SERVICES="sonarr radarr prowlarr bazarr jackett lidarr readarr qbittorrent transmission-daemon transmission-common"
+# ALL_PACKAGES="sonarr radarr prowlarr bazarr jackett lidarr readarr qbittorrent transmission-daemon transmission-common"
+
+# Runtime flags
+# DRY_RUN="${DRY_RUN:-0}"
+# DEBUG="${DEBUG:-0}"
+# NO_COLOR="${NO_COLOR:-0}"
+# VPN_MODE="${DEFAULT_VPN_MODE}"
+
+# Critical host ports we may free up
+# CRITICAL_PORTS="${QBT_HTTP_PORT_HOST} ${SONARR_PORT} ${RADARR_PORT} ${PROWLARR_PORT} ${BAZARR_PORT} ${FLARESOLVERR_PORT} ${GLUETUN_CONTROL_PORT}"

--- a/arrstack-uninstall.sh
+++ b/arrstack-uninstall.sh
@@ -71,6 +71,10 @@ backup_all() {
       tar -C "${ARR_BASE}" -czf "${BACKUP_SUBDIR}/$(basename "$d").tgz" "$(basename "$d")"
     fi
   done
+  note "Backing up arrconf directory"
+  if [[ -d "${ARRCONF_DIR}" ]]; then
+    tar -C "$(dirname "${ARRCONF_DIR}")" -czf "${BACKUP_SUBDIR}/arrconf.tgz" "$(basename "${ARRCONF_DIR}")"
+  fi
   note "Backing up docker app configs"
   if [[ -d "${ARR_DOCKER_DIR}" ]]; then
     while IFS= read -r dir; do
@@ -200,7 +204,9 @@ purge_arrconf() {
   read -r -p "Purge arrconf (secrets) directory? (y/N) " ans
   [[ $ans =~ ^[Yy]$ ]] || { note "Kept ${ARRCONF_DIR}"; return 0; }
   mkdir -p "${BACKUP_SUBDIR}"
-  tar -C "$(dirname "$ARRCONF_DIR")" -czf "${BACKUP_SUBDIR}/arrconf.tgz" "$(basename "$ARRCONF_DIR")"
+  if [[ ! -f "${BACKUP_SUBDIR}/arrconf.tgz" ]]; then
+    tar -C "$(dirname "$ARRCONF_DIR")" -czf "${BACKUP_SUBDIR}/arrconf.tgz" "$(basename "$ARRCONF_DIR")"
+  fi
   rm -rf "$ARRCONF_DIR"
   ok "Purged arrconf (backup at ${BACKUP_SUBDIR}/arrconf.tgz)"
 }

--- a/arrstack.sh
+++ b/arrstack.sh
@@ -61,14 +61,21 @@ ALL_CONTAINERS="gluetun qbittorrent sonarr radarr prowlarr bazarr flaresolverr j
 ALL_NATIVE_SERVICES="sonarr radarr prowlarr bazarr jackett lidarr readarr qbittorrent transmission-daemon transmission-common"
 ALL_PACKAGES="sonarr radarr prowlarr bazarr jackett lidarr readarr qbittorrent transmission-daemon transmission-common"
 
-# Critical host ports we may free up
-CRITICAL_PORTS="${QBT_HTTP_PORT_HOST} ${SONARR_PORT} ${RADARR_PORT} ${PROWLARR_PORT} ${BAZARR_PORT} ${FLARESOLVERR_PORT} ${GLUETUN_CONTROL_PORT}"
-
 # Runtime flags
 DRY_RUN="${DRY_RUN:-0}"
 DEBUG="${DEBUG:-0}"
 NO_COLOR="${NO_COLOR:-0}"
 VPN_MODE="${DEFAULT_VPN_MODE}"
+
+# Source optional user overrides
+USER_CONF="${ARRCONF_DIR}/userconf.sh"
+if [[ -f "${USER_CONF}" ]]; then
+  # shellcheck source=/dev/null
+  . "${USER_CONF}"
+fi
+
+# Critical host ports we may free up (recomputed after overrides)
+CRITICAL_PORTS="${CRITICAL_PORTS:-${QBT_HTTP_PORT_HOST} ${SONARR_PORT} ${RADARR_PORT} ${PROWLARR_PORT} ${BAZARR_PORT} ${FLARESOLVERR_PORT} ${GLUETUN_CONTROL_PORT}}"
 
 # Export for compose templating
 export ARR_BASE ARR_DOCKER_DIR ARR_STACK_DIR ARR_BACKUP_DIR LEGACY_VPNCONFS_DIR ARRCONF_DIR


### PR DESCRIPTION
## Summary
- allow overriding arrstack defaults via `arrconf/userconf.sh`
- back up `arrconf` during uninstalls and purge safely
- document user overrides and track the config file in git

## Testing
- `bash -n arrstack.sh arrstack-uninstall.sh arrconf/userconf.sh`
- `shellcheck arrstack.sh arrstack-uninstall.sh arrconf/userconf.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c656be72208329a33ff9b90b0dc565