### PR TITLE
Preseed qBittorrent config and loopback-bound Gluetun API

### DIFF
--- a/arrconf/userconf.sh
+++ b/arrconf/userconf.sh
@@ -18,6 +18,7 @@
 # LAN_IP="192.168.1.50" # set to your host's LAN IP
 # GLUETUN_CONTROL_PORT="8000" # Gluetun control server port
 # GLUETUN_CONTROL_HOST="127.0.0.1" # Host used for Gluetun control server checks
+# GLUETUN_HEALTH_TARGET="1.1.1.1:443" # Health check address for Gluetun
 
 # Media/Downloads layout
 # MEDIA_DIR="/media/mediasmb"
@@ -31,7 +32,7 @@
 # QBT_WEBUI_PORT="8080"     # qBittorrent WebUI port inside container
 # QBT_HTTP_PORT_HOST="8080" # host port mapped to qBittorrent
 # QBT_USER=""
-# QBT_PASS=""
+# QBT_PASS="" # plain text; requires OpenSSL 3 or will be ignored
 # GLUETUN_API_KEY=""
 
 # Service ports (host:container)


### PR DESCRIPTION
## Summary
- seed qBittorrent config with LAN-safe defaults and optional credentials
- bind Gluetun control API to loopback and enhance PF up-hook
- hash plain-text `QBT_PASS` using OpenSSL 3 when available and fall back to qBittorrent's temporary password otherwise
- document OpenSSL 3 requirement and optional nature of `QBT_PASS`
- reference loopback and health check addresses via variables for consistency

## Testing
- `bash -n arrstack.sh`
- `bash -n arrconf/userconf.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c65d6ff1f88329b4faceb35ca1bb16