### PR TITLE
Add ProtonVPN country selection and fastest switching

### DIFF
--- a/.aliasarr
+++ b/.aliasarr
@@ -43,6 +43,8 @@ RADARR_PORT="$(_arr_get RADARR_PORT)"; [[ -n "$RADARR_PORT" ]] || RADARR_PORT=78
 PROWLARR_PORT="$(_arr_get PROWLARR_PORT)"; [[ -n "$PROWLARR_PORT" ]] || PROWLARR_PORT=9696
 BAZARR_PORT="$(_arr_get BAZARR_PORT)"; [[ -n "$BAZARR_PORT" ]] || BAZARR_PORT=6767
 FLARESOLVERR_PORT="$(_arr_get FLARESOLVERR_PORT)"; [[ -n "$FLARESOLVERR_PORT" ]] || FLARESOLVERR_PORT=8191
+SERVER_COUNTRIES="$(_arr_get SERVER_COUNTRIES)"
+SERVER_CC_PRIORITY="$(_arr_get SERVER_CC_PRIORITY)"
 
 # Known services in this project (compose names)
 ARR_SERVICES=(gluetun qbittorrent sonarr radarr prowlarr bazarr flaresolverr)
@@ -160,6 +162,85 @@ glue.ip()     { curl -fsS -u "gluetun:${GLUETUN_API_KEY}" "http://${LAN_IP}:${GL
 glue.pf()     { pvpn port; echo; }
 glue.health() { docker inspect --format '{{.State.Health.Status}}' gluetun 2>/dev/null || echo n/a; }
 
+arr_vpn_servers() {
+  curl -fsS -u "gluetun:${GLUETUN_API_KEY}" \
+    "http://${LAN_IP}:${GLUETUN_CONTROL_PORT}/v1/servers" |
+    jq -r '.protonvpn[].country' | sort -u
+}
+
+_arr_vpn_switch() {
+  local cc="$1"
+  if wget -qO- --method=PUT \
+      --header="Content-Type: application/json" \
+      --user="gluetun:${GLUETUN_API_KEY}" \
+      "http://${LAN_IP}:${GLUETUN_CONTROL_PORT}/v1/settings" \
+      --post-data "{\"server_countries\":[\"${cc}\"]}" >/dev/null 2>&1; then
+    echo "Requested Gluetun switch to: ${cc}"
+    wget -qO- --method=PUT --user="gluetun:${GLUETUN_API_KEY}" \
+      "http://${LAN_IP}:${GLUETUN_CONTROL_PORT}/v1/openvpn/restart" >/dev/null 2>&1 || true
+    return 0
+  fi
+  echo "Control API settings PUT not available; restarting with ${cc}…"
+  SERVER_COUNTRIES="${cc}" _arr_dc up -d gluetun || return 1
+  return 0
+}
+
+arr_vpn_country() {
+  local cc="$*"
+  if [ -z "$cc" ]; then
+    echo "Usage: arr_vpn_country <Country Name>"; return 2
+  fi
+  local server_list
+  server_list="$(arr_vpn_servers 2>/dev/null || true)"
+  if [ -n "$server_list" ] && ! echo "$server_list" | grep -Fxq "$cc"; then
+    _arr_warn "${cc} not in server list; using priority order"
+    cc=""
+  fi
+  IFS=',' read -r -a cc_list <<< "${SERVER_CC_PRIORITY}"
+  local candidates=()
+  if [ -n "$cc" ]; then candidates+=("$cc"); fi
+  for c in "${cc_list[@]}"; do
+    [[ " ${candidates[*]} " =~ " $c " ]] || candidates+=("$c")
+  done
+  for cand in "${candidates[@]}"; do
+    _arr_vpn_switch "$cand" && return 0
+    _arr_warn "${cand} failed; trying next"
+  done
+  echo "All VPN country attempts failed"; return 1
+}
+
+arr_vpn_fastest() {
+  local limit="${1:-6}"
+  local tested=0 best_cc="" best_ms=""
+
+  IFS=',' read -r -a cc_list <<< "${SERVER_CC_PRIORITY}"
+  local server_list
+  server_list="$(arr_vpn_servers 2>/dev/null || true)"
+  for cc in "${cc_list[@]}"; do
+    [ $tested -ge $limit ] && break
+    if [ -n "$server_list" ] && ! echo "$server_list" | grep -Fxq "$cc"; then
+      continue
+    fi
+    _arr_vpn_switch "$cc" >/dev/null 2>&1 || continue
+    sleep 2
+    local ms
+    ms="$( (time -p nc -z -w 2 1.1.1.1 443) 2>&1 | awk '/real/{print $2*1000}' )" || ms="99999"
+    echo "Probe ${cc}: ${ms} ms"
+    if [ -z "$best_ms" ] || [ "${ms%.*}" -lt "${best_ms%.*}" ]; then
+      best_ms="$ms"; best_cc="$cc"
+    fi
+    tested=$((tested+1))
+  done
+
+  if [ -n "$best_cc" ]; then
+    echo "Fastest (heuristic): ${best_cc} (${best_ms} ms)"
+    _arr_vpn_switch "$best_cc"
+  else
+    echo "No result; using priority order fallback: ${cc_list[0]}"
+    _arr_vpn_switch "${cc_list[0]}"
+  fi
+}
+
 # ----------------[ qBittorrent helpers ]----------------
 _qbt_base()   { printf "http://%s:%s" "$QBT_HOST" "$QBT_HTTP_PORT_HOST"; }
 _qbt_cookie() { printf "/tmp/qbt-%s.cookie" "$USER"; }
@@ -265,5 +346,8 @@ alias pvpnstatus='pvpn status'
 alias pvpnconnect='pvpn connect'
 alias pvpnreconnect='pvpn reconnect'
 alias pvpnmode='pvpn mode'
+alias arrvpncountry='arr_vpn_country'
+alias arrvpnfastest='arr_vpn_fastest'
+alias arrvpnservers='arr_vpn_servers'
 
 # End of arr-stack/.aliasarr

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ By default the stack connects with **OpenVPN** for reliable port forwarding; **W
 2. **Review and customise configuration:**
 
    * Defaults live in the `USER CONFIG` section of `arrstack.sh`. To keep the installer clean, override any of these settings in `arrconf/userconf.sh` by uncommenting the lines you need; the file is sourced on every run so you can adjust it before the first install or later and rerun the script.
-  * Common tweaks: `LAN_IP`, download/media paths, qBittorrent credentials (`QBT_USER`/`QBT_PASS`), `QBT_WEBUI_PORT` (single source for the WebUI port), `GLUETUN_CONTROL_HOST`, `TIMEZONE`, and Proton server options (`SERVER_COUNTRIES`, `DEFAULT_VPN_MODE`).
+  * Common tweaks: `LAN_IP`, download/media paths, qBittorrent credentials (`QBT_USER`/`QBT_PASS`), `QBT_WEBUI_PORT` (single source for the WebUI port), `GLUETUN_CONTROL_HOST`, `TIMEZONE`, and Proton server options (`SERVER_COUNTRIES`, `DEFAULT_VPN_MODE`, `SERVER_CC_PRIORITY`).
     * Set `QBT_PASS` in **plain text** – the installer hashes it with PBKDF2 (via OpenSSL 3) before writing `qBittorrent.conf`. If OpenSSL 3 isn't available, the script warns and ignores these values.
 
    ```bash
@@ -137,6 +137,28 @@ pvpn creds        # update Proton username/password (adds +pmp automatically)
 pvpn paths        # show credential & config locations
 pvpn portsync     # force qB to use the currently forwarded port
 ```
+
+1. **Initial location is random within `SERVER_COUNTRIES`.** To control where you start, keep `SERVER_COUNTRIES` short (1–3) with **privacy-friendly countries**. We default to:
+
+   ```
+   SERVER_COUNTRIES="Switzerland,Iceland,Sweden,Netherlands"
+   ```
+
+   * Why these? Proton’s **Secure Core** runs in **Switzerland, Iceland, Sweden** (privacy-strong); **Netherlands** and **Romania** have had indiscriminate data retention laws **struck down**; **Luxembourg** has strong data-protection. Other privacy-friendly options: Romania, Luxembourg.
+
+2. **Switching later** is easy via `.aliasarr`:
+
+   * `arr_vpn_country "<Country>"` — switch to a specific country; if it fails, the function retries through `SERVER_CC_PRIORITY`.
+   * `arr_vpn_fastest [N]` — probe the first *N* countries in `SERVER_CC_PRIORITY` (default 6), pick the lowest RTT from AU, and switch there.
+   * `arr_vpn_servers` — list Proton countries from the current server list.
+
+3. **Priority list used for switching/speed trials from Australia** (fast → slow):
+
+   ```
+   SERVER_CC_PRIORITY="Australia,Singapore,Japan,Hong Kong,United States,United Kingdom,Netherlands,Germany,Switzerland,Spain,Romania,Luxembourg"
+   ```
+
+   * Rationale: geographic proximity/typical subsea paths from AU → SE/E Asia → US-West → Western Europe. Validate with your line by running `arr_vpn_fastest`.
 
 ---
 
@@ -227,3 +249,4 @@ Run the provided `arrstack-uninstall.sh` script to back up existing configuratio
 * Proton credentials live at `./arrconf/proton.auth` (`chmod 600` inside a `chmod 700` folder). Legacy files under `~/srv/docker/gluetun/` or `~/srv/wg-configs/` are migrated automatically. Use your plain Proton username; `+pmp` is added automatically for OpenVPN port forwarding.
 * `.env` is also `chmod 600` and only contains what Compose needs.
 * You can customise paths and ports by editing the variables at the top of the script before running it.
+

--- a/arrconf/userconf.sh
+++ b/arrconf/userconf.sh
@@ -50,7 +50,8 @@
 # Proton defaults and selection
 # PROTON_AUTH_FILE="${ARRCONF_DIR}/proton.auth"
 # DEFAULT_VPN_MODE="openvpn" # openvpn (preferred) | wireguard (fallback)
-# SERVER_COUNTRIES="Netherlands,Germany,Switzerland,Australia,Spain,United States"
+# SERVER_COUNTRIES="Switzerland,Iceland,Sweden,Netherlands" # additional: Romania,Luxembourg
+# SERVER_CC_PRIORITY="Australia,Singapore,Japan,Hong Kong,United States,United Kingdom,Netherlands,Germany,Switzerland,Spain,Romania,Luxembourg"
 # DEFAULT_COUNTRY="Australia"
 
 # Service/package lists (kept at least as broad as originals)

--- a/arrstack.sh
+++ b/arrstack.sh
@@ -56,7 +56,8 @@ TIMEZONE="Australia/Sydney"
 # Proton defaults and selection
 PROTON_AUTH_FILE="${ARRCONF_DIR}/proton.auth"
 DEFAULT_VPN_MODE="openvpn" # openvpn (preferred) | wireguard (fallback)
-SERVER_COUNTRIES="Netherlands,Germany,Switzerland,Australia,Spain,United States"
+SERVER_COUNTRIES="Switzerland,Iceland,Sweden,Netherlands" # additional: Romania,Luxembourg
+SERVER_CC_PRIORITY="Australia,Singapore,Japan,Hong Kong,United States,United Kingdom,Netherlands,Germany,Switzerland,Spain,Romania,Luxembourg"
 DEFAULT_COUNTRY="Australia"
 
 # Service/package lists (kept at least as broad as originals)
@@ -85,7 +86,7 @@ export ARR_BASE ARR_DOCKER_DIR ARR_STACK_DIR ARR_BACKUP_DIR LEGACY_VPNCONFS_DIR 
 export MEDIA_DIR DOWNLOADS_DIR COMPLETED_DIR MEDIA_DIR MOVIES_DIR TV_DIR SUBS_DIR
 export QBT_WEBUI_PORT QBT_HTTP_PORT_HOST QBT_USER QBT_PASS QBT_SAVE_PATH QBT_TEMP_PATH LAN_IP GLUETUN_CONTROL_PORT GLUETUN_CONTROL_HOST GLUETUN_HEALTH_TARGET PUID PGID TIMEZONE
 export SONARR_PORT RADARR_PORT PROWLARR_PORT BAZARR_PORT FLARESOLVERR_PORT
-export DEFAULT_VPN_MODE SERVER_COUNTRIES DEFAULT_COUNTRY GLUETUN_API_KEY
+export DEFAULT_VPN_MODE SERVER_COUNTRIES SERVER_CC_PRIORITY DEFAULT_COUNTRY GLUETUN_API_KEY
 
 # ----------------------------[ LOGGING ]---------------------------------------
 if [[ "${NO_COLOR}" -eq 0 && -t 1 ]]; then
@@ -450,6 +451,7 @@ SUBS_DIR=${SUBS_DIR}
 VPN_MODE=${VPN_MODE}
 VPN_TYPE=${VPN_MODE}
 SERVER_COUNTRIES=${CN}
+SERVER_CC_PRIORITY="${SERVER_CC_PRIORITY}"
 UPDATER_PERIOD=24h
 EOF
   if [[ "${VPN_MODE}" = "openvpn" ]]; then


### PR DESCRIPTION
## Summary
- Trim default SERVER_COUNTRIES to core privacy jurisdictions and extend SERVER_CC_PRIORITY with fallback options
- Add arr_vpn_servers and enhance arr_vpn_country and arr_vpn_fastest to validate against server list and retry by priority
- Document new helpers and priority-based retries while removing README citations

## Testing
- `bash -n arrstack.sh`
- `bash -n arrconf/userconf.sh`
- `bash -n .aliasarr`


------
https://chatgpt.com/codex/tasks/task_e_68c67f292240832997ec3ae12f675b5b