### PR TITLE
Implement bash-based qBittorrent credential hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ By default the stack connects with **OpenVPN** for reliable port forwarding; **W
   Install Docker & tools (if needed):
   ```bash
   sudo apt update
-  sudo apt install -y docker.io docker-compose-plugin curl wget openssl iproute2
+  sudo apt install -y docker.io docker-compose-plugin curl wget openssl iproute2 xxd
   sudo systemctl enable --now docker
   ```
 
-> Pre-seeding qBittorrent credentials requires **OpenSSL 3** (Ubuntu 22.04+ ships it). If only an older OpenSSL is found, the installer falls back to qBittorrent's temporary password. Setting `QBT_USER`/`QBT_PASS` is optional.
+> Pre-seeding qBittorrent credentials requires **OpenSSL 3** (with `kdf`), `xxd`, and `base64`. If any are missing, the installer falls back to qBittorrent's temporary password. Setting `QBT_USER`/`QBT_PASS` is optional.
 
 ---
 
@@ -53,7 +53,7 @@ By default the stack connects with **OpenVPN** for reliable port forwarding; **W
 
    * Defaults live in `arrconf/userconf.defaults.sh`. Copy it to `arrconf/userconf.sh` and edit the values you want to override; the overrides file is sourced on every run so you can adjust it before the first install or later and rerun the script.
   * Common tweaks: `LAN_IP`, download/media paths, qBittorrent credentials (`QBT_USER`/`QBT_PASS`), `QBT_WEBUI_PORT` (single source for the WebUI port), `GLUETUN_CONTROL_HOST`, `TIMEZONE`, and Proton server options (`SERVER_COUNTRIES`, `DEFAULT_VPN_MODE`, `SERVER_CC_PRIORITY`).
-    * Set `QBT_PASS` in **plain text** – the installer hashes it with PBKDF2 (via OpenSSL 3) before writing `qBittorrent.conf`. If OpenSSL 3 isn't available, the script warns and ignores these values.
+      * Set `QBT_PASS` in **plain text** – the installer hashes it with PBKDF2 (via OpenSSL 3, `xxd`, and `base64`) before writing `qBittorrent.conf`. If the hashing deps are missing, the script warns and ignores these values.
 
    ```bash
    cp arrconf/userconf.defaults.sh arrconf/userconf.sh  # first-time: create overrides
@@ -78,9 +78,9 @@ By default the stack connects with **OpenVPN** for reliable port forwarding; **W
 
 4. Open the UIs (replace `<LAN_IP>` with your host's LAN IP; default `192.168.1.11`):
 
-    * **qBittorrent:** `http://${LAN_IP}:${QBT_HTTP_PORT_HOST}`
-      * If `${QBT_USER}` and `${QBT_PASS}` (plain text) are set and OpenSSL 3 is available, the script hashes the password and you can log in with those credentials.
-      * Otherwise (or if OpenSSL 3 is missing) the installer prints a temporary admin password from the logs; log in as `admin/<printed>` and change it in qBittorrent.
+      * **qBittorrent:** `http://${LAN_IP}:${QBT_HTTP_PORT_HOST}`
+        * If `${QBT_USER}` and `${QBT_PASS}` are set and hashing deps are present (OpenSSL 3 with `kdf`, `xxd`, `base64`), the script hashes the password and you can log in with those credentials.
+        * Otherwise the installer prints a temporary admin password from the logs; log in as `admin/<printed>` and change it in qBittorrent.
      * **Sonarr:** `http://${LAN_IP}:${SONARR_PORT}`
      * **Radarr:** `http://${LAN_IP}:${RADARR_PORT}`
      * **Prowlarr:** `http://${LAN_IP}:${PROWLARR_PORT}`

--- a/arrstack.sh
+++ b/arrstack.sh
@@ -156,13 +156,20 @@ atomic_write() {
 check_deps() {
   step "1/15 Checking prerequisites"
   [[ "$(whoami)" == "${USER_NAME}" ]] || die "Run as '${USER_NAME}' (current: $(whoami))"
-  for b in docker wget curl openssl; do command -v "$b" >/dev/null 2>&1 || die "Missing dependency: $b"; done
+  for b in docker wget curl; do command -v "$b" >/dev/null 2>&1 || die "Missing dependency: $b"; done
   docker compose version >/dev/null 2>&1 || die "Docker Compose v2 not available"
-  if ! command -v ss >/dev/null 2>&1; then
-    note "Installing iproute2 for net utils"
+
+  local pkgs=()
+  command -v ss >/dev/null 2>&1 || pkgs+=(iproute2)
+  command -v openssl >/dev/null 2>&1 || pkgs+=(openssl)
+  command -v xxd >/dev/null 2>&1 || pkgs+=(xxd)
+  if (( ${#pkgs[@]} )); then
+    note "Installing packages: ${pkgs[*]}"
     run_cmd --spinner sudo apt-get update -y || true
-    run_cmd --spinner sudo apt-get install -y iproute2 || true
+    run_cmd --spinner sudo apt-get install -y "${pkgs[@]}" || true
   fi
+
+  for b in openssl xxd; do command -v "$b" >/dev/null 2>&1 || die "Missing dependency: $b"; done
   ok "Docker & Compose OK"
 }
 
@@ -540,31 +547,92 @@ Downloads\\TempPathEnabled=true
 CONFEOF
     chown "${PUID}:${PGID}" "${conf}"; chmod 0640 "${conf}"
   fi
+}
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; return 1; }; }
+
+check_hash_deps() {
+  need openssl && need xxd && need base64 && need sed && need awk && need grep || return 1
+  if ! openssl version | grep -qE 'OpenSSL 3\.'; then
+    echo "OpenSSL 3 required (found: $(openssl version))" >&2; return 1
+  fi
+  if ! openssl kdf -help >/dev/null 2>&1; then
+    echo "'openssl kdf' subcommand not available; need OpenSSL 3" >&2; return 1
+  fi
+}
+
+# Inputs: QBT_USER, QBT_PASS
+# Outputs: SALT_B64, DK_B64
+derive_qbt_hash() {
+  : "${QBT_USER:?QBT_USER not set}" "${QBT_PASS:?QBT_PASS not set}"
+  local salt_hex dk_b64 salt_b64
+  salt_hex="$(openssl rand -hex 16)"
+  dk_b64="$(openssl kdf -binary -keylen 64 PBKDF2 \
+              -kdfopt digest:SHA512 \
+              -kdfopt pass:"${QBT_PASS}" \
+              -kdfopt hexsalt:"${salt_hex}" \
+              -kdfopt iter:100000 \
+            | base64 | tr -d '\n')"
+  salt_b64="$(printf '%s' "${salt_hex}" | xxd -r -p | base64 | tr -d '\n')"
+  export SALT_B64="${salt_b64}" DK_B64="${dk_b64}"
+}
+
+write_qbt_conf_hash() {
+  local dir="${ARR_DOCKER_DIR}/qbittorrent"
+  local cfg="${dir}/qBittorrent.conf"
+  install -d -m 0750 -o "${PUID}" -g "${PGID}" "${dir}"
+  if [ ! -f "${cfg}" ]; then
+    cat >"${cfg}" <<'CONFEOF'
+[Preferences]
+WebUI\BypassLocalAuth=true
+WebUI\CSRFProtection=true
+WebUI\ClickjackingProtection=true
+WebUI\HostHeaderValidation=true
+WebUI\HTTPS\Enabled=false
+WebUI\Address=*
+WebUI\ServerDomains=*
+WebUI\Port=${QBT_WEBUI_PORT}
+Connection\UPnP=false
+Connection\UseUPnP=false
+Connection\UseNAT-PMP=false
+Downloads\SavePath=${QBT_SAVE_PATH}
+Downloads\TempPath=${QBT_TEMP_PATH}
+Downloads\TempPathEnabled=true
+CONFEOF
+  fi
+
+  grep -q '^\[Preferences\]' "${cfg}" || printf '\n[Preferences]\n' >> "${cfg}"
+
+  if grep -q '^WebUI\\Username=' "${cfg}"; then
+    sed -i.bak "s#^WebUI\\Username=.*#WebUI\\Username=${QBT_USER}#g" "${cfg}"
+  else
+    printf 'WebUI\\Username=%s\n' "${QBT_USER}" >> "${cfg}"
+  fi
+
+  local pb_line="WebUI\\Password_PBKDF2=\"@ByteArray(${SALT_B64}:${DK_B64})\""
+  if grep -q '^WebUI\\Password_PBKDF2=' "${cfg}"; then
+    sed -i.bak "s#^WebUI\\Password_PBKDF2=.*#${pb_line//#/\\#}#g" "${cfg}"
+  else
+    printf '%s\n' "${pb_line}" >> "${cfg}"
+  fi
+
+  chown "${PUID}:${PGID}" "${cfg}"; chmod 0640 "${cfg}"
+  rm -f "${cfg}.bak" 2>/dev/null || true
+}
+
+seed_qbt_credentials_if_requested() {
   if [ -n "${QBT_USER:-}" ] && [ -n "${QBT_PASS:-}" ]; then
-    if ! openssl version | grep -q 'OpenSSL 3\.'; then
-      warn "OpenSSL 3 required for PBKDF2 password hashing; skipping credential pre-seed"
+    if check_hash_deps; then
+      derive_qbt_hash
+      write_qbt_conf_hash
+      echo "qBittorrent WebUI creds pre-seeded for user '${QBT_USER}' (password hashed)."
+    else
+      echo "Warning: hashing deps missing; will not pre-seed qB credentials. A temporary password will be generated on first start."
       QBT_USER=""
       QBT_PASS=""
-      return
     fi
-    if grep -q '^WebUI\\Username=' "${conf}"; then
-      sed -i "s|^WebUI\\Username=.*|WebUI\\Username=${QBT_USER}|" "${conf}"
-    else
-      echo "WebUI\\Username=${QBT_USER}" >> "${conf}"
-    fi
-    local salt_hex salt_b64 dk_b64 hash_line
-    salt_hex=$(openssl rand -hex 16)
-    dk_b64=$(openssl kdf -binary -keylen 64 PBKDF2 \
-      -kdfopt digest:SHA512 \
-      -kdfopt pass:"${QBT_PASS}" \
-      -kdfopt hexsalt:"${salt_hex}" \
-      -kdfopt iter:100000 | base64 -w0)
-    salt_b64=$(printf "%s" "${salt_hex}" | xxd -r -p | base64 -w0)
-    hash_line="WebUI\\Password_PBKDF2=\"@ByteArray(${salt_b64}:${dk_b64})\""
-    sed -i '/^WebUI\\Password_PBKDF2=/d' "${conf}"
-    echo "${hash_line}" >> "${conf}"
-    chown "${PUID}:${PGID}" "${conf}"; chmod 0640 "${conf}"
-    note "Using provided WebUI credentials: ${QBT_USER} / (hashed password stored)"
+  else
+    echo "No QBT_USER/QBT_PASS provided; will use LSIO temporary password flow."
   fi
 }
 
@@ -927,6 +995,7 @@ main() {
   write_env
   seed_wireguard_from_conf
   ensure_qbt_conf
+  seed_qbt_credentials_if_requested
   write_compose
   pull_images
   start_with_checks


### PR DESCRIPTION
## Summary
- add bash PBKDF2 hashing with dependency checks for OpenSSL 3, xxd, and base64
- merge qBittorrent username and PBKDF2 hash into config without overwriting user settings
- document hashing dependencies and explain hashed vs temporary credential paths
- auto-install OpenSSL and xxd when absent so credential hashing works out of the box

## Testing
- `bash -n arrstack.sh`
- `salt_hex=$(openssl rand -hex 16); openssl kdf -binary -keylen 64 -kdfopt digest:SHA512 -kdfopt pass:password -kdfopt hexsalt:$salt_hex -kdfopt iter:100000 PBKDF2 | base64 | tr -d '\n' && echo`
- `PATH="/tmp/bin:/usr/bin:/bin" DRY_RUN=1 ARR_BASE=/tmp/arrbase ARRCONF_DIR=/tmp/arrconf QBT_USER=foo QBT_PASS=bar bash arrstack.sh 2>&1 | head -n 20` *(fails: Missing dependency: openssl; apt install step invoked)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d19801188329b218c0072dd864b0