### PR TITLE
Implement bash-based qBittorrent credential hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ By default the stack connects with **OpenVPN** for reliable port forwarding; **W
   Install Docker & tools (if needed):
   ```bash
   sudo apt update
-  sudo apt install -y docker.io docker-compose-plugin curl wget openssl iproute2
+  sudo apt install -y docker.io docker-compose-plugin curl wget openssl iproute2 xxd
   sudo systemctl enable --now docker
   ```
 
-> Pre-seeding qBittorrent credentials requires **OpenSSL 3** (Ubuntu 22.04+ ships it). If only an older OpenSSL is found, the installer falls back to qBittorrent's temporary password. Setting `QBT_USER`/`QBT_PASS` is optional.
+> Pre-seeding qBittorrent credentials requires **OpenSSL 3** (with `kdf`), `xxd`, and `base64`. If any are missing, the installer falls back to qBittorrent's temporary password. Setting `QBT_USER`/`QBT_PASS` is optional.
 
 ---
 
@@ -53,7 +53,7 @@ By default the stack connects with **OpenVPN** for reliable port forwarding; **W
 
    * Defaults live in `arrconf/userconf.defaults.sh`. Copy it to `arrconf/userconf.sh` and edit the values you want to override; the overrides file is sourced on every run so you can adjust it before the first install or later and rerun the script.
   * Common tweaks: `LAN_IP`, download/media paths, qBittorrent credentials (`QBT_USER`/`QBT_PASS`), `QBT_WEBUI_PORT` (single source for the WebUI port), `GLUETUN_CONTROL_HOST`, `TIMEZONE`, and Proton server options (`SERVER_COUNTRIES`, `DEFAULT_VPN_MODE`, `SERVER_CC_PRIORITY`).
-    * Set `QBT_PASS` in **plain text** – the installer hashes it with PBKDF2 (via OpenSSL 3) before writing `qBittorrent.conf`. If OpenSSL 3 isn't available, the script warns and ignores these values.
+      * Set `QBT_PASS` in **plain text** – the installer hashes it with PBKDF2 (via OpenSSL 3, `xxd`, and `base64`) before writing `qBittorrent.conf`. If the hashing deps are missing, the script warns and ignores these values.
 
    ```bash
    cp arrconf/userconf.defaults.sh arrconf/userconf.sh  # first-time: create overrides
@@ -78,9 +78,9 @@ By default the stack connects with **OpenVPN** for reliable port forwarding; **W
 
 4. Open the UIs (replace `<LAN_IP>` with your host's LAN IP; default `192.168.1.11`):
 
-    * **qBittorrent:** `http://${LAN_IP}:${QBT_HTTP_PORT_HOST}`
-      * If `${QBT_USER}` and `${QBT_PASS}` (plain text) are set and OpenSSL 3 is available, the script hashes the password and you can log in with those credentials.
-      * Otherwise (or if OpenSSL 3 is missing) the installer prints a temporary admin password from the logs; log in as `admin/<printed>` and change it in qBittorrent.
+      * **qBittorrent:** `http://${LAN_IP}:${QBT_HTTP_PORT_HOST}`
+        * If `${QBT_USER}` and `${QBT_PASS}` are set and hashing deps are present (OpenSSL 3 with `kdf`, `xxd`, `base64`), the script hashes the password and you can log in with those credentials.
+        * Otherwise the installer prints a temporary admin password from the logs; log in as `admin/<printed>` and change it in qBittorrent.
      * **Sonarr:** `http://${LAN_IP}:${SONARR_PORT}`
      * **Radarr:** `http://${LAN_IP}:${RADARR_PORT}`
      * **Prowlarr:** `http://${LAN_IP}:${PROWLARR_PORT}`


### PR DESCRIPTION
## Summary
- add bash PBKDF2 hashing with dependency checks for OpenSSL 3 and base64, with optional xxd support
- merge qBittorrent username and PBKDF2 hash into config without overwriting user settings
- document hashing dependencies and explain hashed vs temporary credential paths
- auto-install OpenSSL and xxd when absent so credential hashing works out of the box
- fix openssl kdf usage and allow hashing to succeed even when xxd is missing
- try to install docker, curl, wget, iproute2, openssl, xxd, and docker compose plugin automatically before running

## Testing
- `bash -n arrstack.sh`
- `salt_hex=$(openssl rand -hex 16); openssl kdf -binary -keylen 64 -kdfopt digest:SHA512 -kdfopt pass:password -kdfopt hexsalt:$salt_hex -kdfopt iter:100000 PBKDF2 | base64 | tr -d '\n'`
- `salt_hex=$(openssl rand -hex 16); salt_b64=$(printf "%b" "$(printf "%s" $salt_hex | sed 's/../\\x&/g')" | base64 | tr -d '\n'); echo "salt_hex=$salt_hex"; echo "salt_b64=$salt_b64"`
- `ARR_BASE=/tmp/arrbase ARRCONF_DIR=/tmp/arrconf QBT_USER=foo QBT_PASS=bar DRY_RUN=1 bash arrstack.sh 2>&1 | head -n 40` *(fails: missing dependency docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d19801188329b218c0072dd864b0