### PR TITLE
Use multi-arch images for Sonarr/Radarr and fix Gluetun YAML quoting

### DIFF
--- a/arrstack.sh
+++ b/arrstack.sh
@@ -498,10 +498,14 @@ UPDATER_PERIOD=24h
 EOF
   if [[ "${VPN_MODE}" = "openvpn" ]]; then
     [[ -n "${PU}" && -n "${PP}" ]] || die "Missing Proton credentials at ${PROTON_AUTH_FILE}"
+    local OUSER
+    OUSER="$(ensure_pmp "${PU}")"
     {
-      echo "OPENVPN_USER=$(ensure_pmp "${PU}")"
+      echo "OPENVPN_USER=${OUSER}"
       echo "OPENVPN_PASSWORD=${PP}"
     } >>"${envf}"
+    atomic_write "${ARRCONF_DIR}/proton.env" "OPENVPN_USER=${OUSER}\nOPENVPN_PASSWORD=${PP}\n"
+    run_cmd chmod 600 "${ARRCONF_DIR}/proton.env"
   else
     {
       echo "WIREGUARD_MTU=1320"
@@ -687,17 +691,14 @@ services:
     cap_add: ["NET_ADMIN"]
     devices:
       - /dev/net/tun:/dev/net/tun
+    env_file:
+      - ./arrconf/proton.env
     environment:
       - TZ=${TIMEZONE}
       - VPN_SERVICE_PROVIDER=protonvpn
       - VPN_TYPE=${VPN_TYPE}
 YAML
-    if [ "${VPN_MODE}" = "openvpn" ]; then
-      cat <<'YAML'
-      - OPENVPN_USER=${OPENVPN_USER}
-      - OPENVPN_PASSWORD=${OPENVPN_PASSWORD}
-YAML
-    else
+    if [ "${VPN_MODE}" = "wireguard" ]; then
       cat <<'YAML'
       - WIREGUARD_PRIVATE_KEY=${WIREGUARD_PRIVATE_KEY}
       - WIREGUARD_ADDRESSES=${WIREGUARD_ADDRESSES}
@@ -709,14 +710,14 @@ YAML
       - VPN_PORT_FORWARDING=on
       # - VPN_PORT_FORWARDING_PROVIDER=protonvpn
       - PORT_FORWARD_ONLY=on
-      - "SERVER_COUNTRIES=${SERVER_COUNTRIES}"
+      - SERVER_COUNTRIES="${SERVER_COUNTRIES}"
       # - FREE_ONLY=off
       # DNS & stability
       - DOT=off
       - UPDATER_PERIOD=${UPDATER_PERIOD}
       - HEALTH_TARGET_ADDRESS=${GLUETUN_HEALTH_TARGET}
       # Control server (RBAC)
-      - HTTP_CONTROL_SERVER_ADDRESS=${GLUETUN_CONTROL_HOST}:${GLUETUN_CONTROL_PORT}
+      - HTTP_CONTROL_SERVER_ADDRESS="${GLUETUN_CONTROL_HOST}:${GLUETUN_CONTROL_PORT}"
       - HTTP_CONTROL_SERVER_LOG=off
       - HTTP_CONTROL_SERVER_AUTH_FILE=/gluetun/auth/config.toml
       - VPN_PORT_FORWARDING_UP_COMMAND=/bin/sh -c '\
@@ -724,7 +725,7 @@ YAML
             wget -qO- --timeout=2 http://${GLUETUN_CONTROL_HOST}:${QBT_HTTP_PORT_HOST}/api/v2/app/version && break || sleep 1; \
           done; \
           wget -qO- --timeout=5 \
-            --header="Referer: http://${GLUETUN_CONTROL_HOST}:${QBT_HTTP_PORT_HOST}/" \
+            --referer="http://${GLUETUN_CONTROL_HOST}:${QBT_HTTP_PORT_HOST}/" \
             --post-data "json={\"listen_port\":{{PORTS}},\"use_upnp\":false,\"use_natpmp\":false}" \
             http://${GLUETUN_CONTROL_HOST}:${QBT_HTTP_PORT_HOST}/api/v2/app/setPreferences >/dev/null 2>&1 || exit 0'
       - PUID=${PUID}
@@ -774,7 +775,7 @@ YAML
     restart: unless-stopped
 
   sonarr:
-    image: ghcr.io/hotio/sonarr:release
+    image: lscr.io/linuxserver/sonarr:latest
     container_name: sonarr
     network_mode: "service:gluetun"
     environment:
@@ -800,7 +801,7 @@ YAML
     restart: unless-stopped
 
   radarr:
-    image: ghcr.io/hotio/radarr:release
+    image: lscr.io/linuxserver/radarr:latest
     container_name: radarr
     network_mode: "service:gluetun"
     environment:
@@ -908,7 +909,11 @@ validate_creds_or_die() {
     if [[ "$OU" != *+pmp ]]; then
       warn "Fixing OPENVPN_USER to include +pmp"
       sed -i '/^OPENVPN_USER=/d' "$ENVF"
-      echo "OPENVPN_USER=$(ensure_pmp "$OU")" >>"$ENVF"
+      printf 'OPENVPN_USER=%s\n' "$(ensure_pmp "$OU")" >>"$ENVF"
+      if [[ -f "${ARRCONF_DIR}/proton.env" ]]; then
+        sed -i '/^OPENVPN_USER=/d' "${ARRCONF_DIR}/proton.env"
+        printf 'OPENVPN_USER=%s\n' "$(ensure_pmp "$OU")" >>"${ARRCONF_DIR}/proton.env"
+      fi
     fi
   fi
 }


### PR DESCRIPTION
## Summary
- use LinuxServer Sonarr image
- use LinuxServer Radarr image
- move Proton credentials to an env file and quote host:port values
- fix Gluetun port forwarding header to prevent docker compose YAML parse errors
- quote Gluetun env values instead of entire environment lines
- align Gluetun port-forwarding up-command and harden Proton env writes

## Testing
- `bash -n arrstack.sh`
- `./arrstack.sh conf-diff`
- `DRY_RUN=1 ./arrstack.sh`
- `python3 - <<'PY' ...`


------
https://chatgpt.com/codex/tasks/task_e_68c6f5e3323883298eca577e7469a74d