### PR TITLE
Prevent failure when stack files are missing

### DIFF
--- a/arrstack.sh
+++ b/arrstack.sh
@@ -200,7 +200,11 @@ compose_cmd() {
 
 stop_stack_if_present() {
   step "2/15 Stopping any existing stack"
-  compose_cmd --spinner down || true
+  if [[ -f "${ARR_STACK_DIR}/docker-compose.yml" && -f "${ARR_ENV_FILE}" ]]; then
+    compose_cmd --spinner down || true
+  else
+    note "No existing stack to stop"
+  fi
 }
 stop_named_containers() {
   note "Removing known containers"


### PR DESCRIPTION
## Summary
- Skip `docker compose down` when the stack's compose or env file is absent

## Testing
- `bash -n arrstack.sh`
- `shellcheck arrstack.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c718392c8883299d35373771806cc1