### PR TITLE
Improve container cleanup and pf-sync handling

### DIFF
--- a/arrconf/userconf.defaults.sh
+++ b/arrconf/userconf.defaults.sh
@@ -63,7 +63,7 @@ SERVER_CC_PRIORITY="${SERVER_CC_PRIORITY:-Australia,Singapore,Japan,Hong Kong,Un
 DEFAULT_COUNTRY="${DEFAULT_COUNTRY:-Australia}"
 
 # Service/package lists used by uninstaller
-ALL_CONTAINERS="${ALL_CONTAINERS:-gluetun qbittorrent sonarr radarr prowlarr bazarr flaresolverr jackett transmission lidarr readarr byparr}"
+ALL_CONTAINERS="${ALL_CONTAINERS:-gluetun qbittorrent pf-sync sonarr radarr prowlarr bazarr flaresolverr jackett transmission lidarr readarr byparr}"
 ALL_NATIVE_SERVICES="${ALL_NATIVE_SERVICES:-sonarr radarr prowlarr bazarr jackett lidarr readarr qbittorrent transmission-daemon transmission-common byparr}"
 ALL_PACKAGES="${ALL_PACKAGES:-sonarr radarr prowlarr bazarr jackett lidarr readarr qbittorrent transmission-daemon transmission-common byparr}"
 


### PR DESCRIPTION
## Summary
- make `docker_rm_if_exists` prefer exact name matches and warn before broad fallbacks
- rewrite compose environment blocks to mapping style and enrich pf-sync with adaptive backoff logging
- add pf-sync to the default cleanup list and surface curl-based Gluetun troubleshooting hints

## Testing
- bash -n arrstack.sh

------
https://chatgpt.com/codex/tasks/task_e_68c90e10f99c832997063f4323c74e0e