### PR TITLE
Expose docker compose progress in installer

### DIFF
--- a/arrstack-uninstall.sh
+++ b/arrstack-uninstall.sh
@@ -163,7 +163,7 @@ stop_stack() {
   step "Stopping Docker stack"
   for d in "${ARR_STACK_DIRS[@]}"; do
     if [[ -d "$d" ]]; then
-      (cd "$d" && docker compose down -v --remove-orphans >/dev/null 2>&1) || true
+      (cd "$d" && docker compose down -v --remove-orphans) || true
     fi
   done
   for c in ${ALL_CONTAINERS}; do

--- a/arrstack.sh
+++ b/arrstack.sh
@@ -78,14 +78,9 @@ _exec_cmd() {
   fi
 
   local rc
-  if [[ "${argv[0]}" == docker && ( "${argv[1]:-}" == compose || "${argv[1]:-}" == pull ) ]]; then
-    if [[ -e /dev/fd/3 ]]; then
-      "${argv[@]}" 2>&1 | tee /dev/fd/3
-      rc=${PIPESTATUS[0]}
-    else
-      "${argv[@]}"
-      rc=$?
-    fi
+  if [[ "${argv[0]}" == docker && -e /dev/fd/3 ]]; then
+    "${argv[@]}" 2>&1 | tee /dev/fd/3
+    rc=${PIPESTATUS[0]}
   else
     "${argv[@]}"
     rc=$?
@@ -94,7 +89,7 @@ _exec_cmd() {
   if (( warn_on_fail )) && (( rc != 0 )); then
     warn "Command failed ($rc): $(_stringify_cmd "${argv[@]}")"
   fi
-  return $rc
+  return "$rc"
 }
 
 run() { _exec_cmd 0 "$@"; }

--- a/arrstack.sh
+++ b/arrstack.sh
@@ -76,8 +76,21 @@ _exec_cmd() {
   if is_dry; then
     return 0
   fi
-  "${argv[@]}"
-  local rc=$?
+
+  local rc
+  if [[ "${argv[0]}" == docker && ( "${argv[1]:-}" == compose || "${argv[1]:-}" == pull ) ]]; then
+    if [[ -e /dev/fd/3 ]]; then
+      "${argv[@]}" 2>&1 | tee /dev/fd/3
+      rc=${PIPESTATUS[0]}
+    else
+      "${argv[@]}"
+      rc=$?
+    fi
+  else
+    "${argv[@]}"
+    rc=$?
+  fi
+
   if (( warn_on_fail )) && (( rc != 0 )); then
     warn "Command failed ($rc): $(_stringify_cmd "${argv[@]}")"
   fi


### PR DESCRIPTION
## Summary
- stream docker compose and pull output to the console while still logging commands
- allow the uninstall helper to show docker compose down output

## Testing
- shellcheck arrstack.sh arrstack-uninstall.sh *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c98114cbe483298e38aa117531e7e0