### PR TITLE
Add installer preflight and host-based gluetun checks

### DIFF
--- a/arrstack.sh
+++ b/arrstack.sh
@@ -166,6 +166,10 @@ parse_args() {
       --wireguard)
         VPN_TYPE="wireguard"
         ;;
+      -y|--yes)
+        ASSUME_YES=1
+        export ASSUME_YES
+        ;;
     esac
     shift
   done
@@ -232,6 +236,59 @@ lan_access_host() {
   else
     printf '%s' "$host"
   fi
+}
+
+# ----------------------------[ PREFLIGHT ]-------------------------------------
+confirm_or_die() {
+  if [ "${ASSUME_YES:-0}" = "1" ]; then
+    return 0
+  fi
+  printf "Proceed with installation? [y/N]: " >&3
+  read -r ans
+  case "$ans" in
+    y|Y|yes|YES) return 0 ;;
+    *) die "Aborted by user" ;;
+  esac
+}
+
+preflight() {
+  step "0a/15 Preflight checks"
+  hydrate_vpn_type_from_env
+  ensure_proton_auth preflight
+  ensure_lan_ip_binding
+  warn_lan_ip
+
+  case "${VPN_TYPE:-${DEFAULT_VPN_TYPE}}" in
+    openvpn)
+      if ! grep -Eq '^PROTON_USER=[^#[:space:]].*' "${PROTON_AUTH_FILE}" 2>/dev/null \
+         || ! grep -Eq '^PROTON_PASS=[^#[:space:]].*' "${PROTON_AUTH_FILE}" 2>/dev/null; then
+        die "VPN_TYPE=openvpn but PROTON_USER/PROTON_PASS not set in ${PROTON_AUTH_FILE}. Edit it (username WITHOUT +pmp) and re-run."
+      fi
+      ;;
+    wireguard)
+      if ! find_wg_conf "proton.conf" >/dev/null 2>&1; then
+        die "VPN_TYPE=wireguard but proton.conf not found in ${ARRCONF_DIR}, ${ARR_DOCKER_DIR}/gluetun or ${LEGACY_VPNCONFS_DIR}."
+      fi
+      ;;
+    *)
+      warn "Unknown VPN_TYPE='${VPN_TYPE}'. Falling back to DEFAULT_VPN_TYPE='${DEFAULT_VPN_TYPE}'."
+      VPN_TYPE="${DEFAULT_VPN_TYPE}"
+      export VPN_TYPE
+      ;;
+  esac
+  export VPN_TYPE
+
+  note "Summary:"
+  local client_host ctrl_bind ctrl_host lan_bind control_port
+  client_host="$(lan_access_host)"
+  lan_bind="${LAN_IP:-0.0.0.0}"
+  control_port="${GLUETUN_CONTROL_PORT:-8000}"
+  ctrl_bind="${lan_bind}:${control_port}"
+  ctrl_host="${client_host}:${control_port}"
+  note "  • VPN_TYPE=${VPN_TYPE}"
+  note "  • LAN_IP=${lan_bind}   Gluetun control bind: ${ctrl_bind}   client URL: ${ctrl_host}"
+  note "  • qBittorrent WebUI host port: ${QBT_HTTP_PORT_HOST} (container: ${QBT_WEBUI_PORT})"
+  confirm_or_die
 }
 
 # ----------------------------[ PRECHECKS ]-------------------------------------
@@ -484,7 +541,10 @@ migrate_legacy_creds() {
 }
 
 ensure_proton_auth() {
-  step "8/15 Ensuring Proton auth"
+  local context="${1:-main}"
+  if [[ "$context" != "preflight" ]]; then
+    step "8/15 Ensuring Proton auth"
+  fi
   harden_arrconf
   if [[ ! -f "${PROTON_AUTH_FILE}" ]]; then
     local migrated=0 rc
@@ -872,7 +932,7 @@ YAML
       - ${ARR_DOCKER_DIR}/gluetun:/gluetun
       - ${ARR_DOCKER_DIR}/gluetun/auth:/gluetun/auth
     ports:
-      - "${LAN_IP:-0.0.0.0}:${GLUETUN_CONTROL_PORT:-8000}:${GLUETUN_CONTROL_PORT:-8000}"          # Gluetun control API via lan_access_host
+      - "${LAN_IP:-0.0.0.0}:${GLUETUN_CONTROL_PORT:-8000}:${GLUETUN_CONTROL_PORT:-8000}"          # Gluetun control API host bind (LAN_IP); clients use lan_access_host()
       - "${LAN_IP:-0.0.0.0}:${QBT_HTTP_PORT_HOST:-8081}:${QBT_WEBUI_PORT:-8080}"   # qB WebUI via gluetun namespace
       - "${LAN_IP:-0.0.0.0}:${SONARR_PORT:-8989}:${SONARR_PORT:-8989}"                    # Sonarr
       - "${LAN_IP:-0.0.0.0}:${RADARR_PORT:-7878}:${RADARR_PORT:-7878}"                    # Radarr
@@ -1218,18 +1278,24 @@ start_with_checks() {
     fi
     note "Waiting for gluetun to report healthy (up to ${max_wait}s)..."
     local waited=0 HEALTH="unknown" IP="" PF="" pf_raw=""
+    local -a auth_flags=()
+    if [ -n "${GLUETUN_API_KEY:-}" ]; then
+      auth_flags=(--user "gluetun:${GLUETUN_API_KEY}")
+    fi
+    local ctrl_host="${GLUETUN_CONTROL_HOST:-127.0.0.1}"
+    local ctrl_port="${GLUETUN_CONTROL_PORT:-8000}"
     while [[ $waited -lt ${max_wait} ]]; do
       HEALTH="$(docker inspect gluetun --format='{{.State.Health.Status}}' 2>/dev/null || echo unknown)"
-      IP="$(docker exec gluetun wget -qO- "http://${GLUETUN_CONTROL_HOST}:${GLUETUN_CONTROL_PORT}/v1/publicip/ip" 2>/dev/null || true)"
+      IP="$(curl -fsS "${auth_flags[@]}" "http://${ctrl_host}:${ctrl_port}/v1/publicip/ip" 2>/dev/null || true)"
       if (( requires_pf )); then
-        pf_raw="$(docker exec gluetun wget -qO- "http://${GLUETUN_CONTROL_HOST}:${GLUETUN_CONTROL_PORT}/v1/openvpn/portforwarded" 2>/dev/null || true)"
+        pf_raw="$(curl -fsS "${auth_flags[@]}" "http://${ctrl_host}:${ctrl_port}/v1/openvpn/portforwarded" 2>/dev/null || true)"
         pf_raw="$(printf '%s' "$pf_raw" | tr -d '\r\n')"
         PF=""
         case "$pf_raw" in
           *:*) PF="${pf_raw##*:}" ;;
           *)   PF="$pf_raw" ;;
         esac
-        if ! printf '%s' "$PF" | grep -Eq '^[1-9][0-9]{4,5}$'; then
+        if ! printf '%s' "$PF" | grep -Eq '^[1-9][0-9]{3,4}$'; then
           PF=""
         fi
       fi
@@ -1266,16 +1332,16 @@ start_with_checks() {
   run_or_warn compose_cmd ps
   local ip pf_port="" client_host
   client_host="$(lan_access_host)"
-  ip="$(wget -qO- "http://${client_host}:${GLUETUN_CONTROL_PORT}/v1/publicip/ip" || true)"
+  ip="$(curl -fsS "${auth_flags[@]}" "http://${client_host}:${GLUETUN_CONTROL_PORT:-8000}/v1/publicip/ip" 2>/dev/null || true)"
   note "Public IP: ${ip}"
   if (( requires_pf )); then
-    pf_raw="$(wget -qO- "http://${client_host}:${GLUETUN_CONTROL_PORT}/v1/openvpn/portforwarded" || true)"
+    pf_raw="$(curl -fsS "${auth_flags[@]}" "http://${client_host}:${GLUETUN_CONTROL_PORT:-8000}/v1/openvpn/portforwarded" 2>/dev/null || true)"
     pf_raw="$(printf '%s' "$pf_raw" | tr -d '\r\n')"
     case "$pf_raw" in
       *:*) pf_port="${pf_raw##*:}" ;;
       *)   pf_port="$pf_raw" ;;
     esac
-    if printf '%s' "$pf_port" | grep -Eq '^[1-9][0-9]{4,5}$'; then
+    if printf '%s' "$pf_port" | grep -Eq '^[1-9][0-9]{3,4}$'; then
       if [[ "$pf_raw" != "$pf_port" && -n "$pf_raw" ]]; then
         note "Forwarded port: ${pf_port} (${pf_raw})"
       else
@@ -1323,6 +1389,7 @@ main() {
   parse_args "$@"
   SCRIPT_START=$(date +%s)
   step "0/15 ARR+VPN merged installer"
+  preflight
   check_deps
   stop_stack_if_present
   stop_named_containers


### PR DESCRIPTION
## Summary
- add a preflight phase with optional --yes confirmation that validates VPN credentials/configs before stopping services
- reuse host curl for Gluetun control polling and expose consistent logging/comment for the LAN bind

## Testing
- bash -n arrstack.sh

------
https://chatgpt.com/codex/tasks/task_e_68ca0afa998c8329a7a6cd6a9eb9133e