### PR TITLE
Adopt native Gluetun port forwarding and update docs

### DIFF
--- a/.aliasarr
+++ b/.aliasarr
@@ -66,7 +66,7 @@ if [[ -z "$SERVER_CC_PRIORITY" ]]; then
 fi
 
 # Known services in this project (compose names)
-ARR_SERVICES=(gluetun qbittorrent pf-sync sonarr radarr prowlarr bazarr flaresolverr)
+ARR_SERVICES=(gluetun qbittorrent sonarr radarr prowlarr bazarr flaresolverr)
 
 # ----------------[ Project-level controls ]----------------
 arr.up()       { _arr_dc up -d; }

--- a/arrconf/userconf.defaults.sh
+++ b/arrconf/userconf.defaults.sh
@@ -35,10 +35,12 @@ GLUETUN_FIREWALL_OUTBOUND_SUBNETS="${GLUETUN_FIREWALL_OUTBOUND_SUBNETS:-192.168.
 GLUETUN_FIREWALL_INPUT_PORTS="${GLUETUN_FIREWALL_INPUT_PORTS:-8081,8989,7878,9696,6767,8191}"
 GLUETUN_HTTPPROXY="${GLUETUN_HTTPPROXY:-off}"
 GLUETUN_SHADOWSOCKS="${GLUETUN_SHADOWSOCKS:-off}"
-GLUETUN_IMAGE="${GLUETUN_IMAGE:-qmcgaw/gluetun:v3.38.0}"
+VPN_PORT_FORWARDING="${VPN_PORT_FORWARDING:-on}"
+VPN_PORT_FORWARDING_PROVIDER="${VPN_PORT_FORWARDING_PROVIDER:-protonvpn}"
+PORT_FORWARD_ONLY="${PORT_FORWARD_ONLY:-on}"
+GLUETUN_IMAGE="${GLUETUN_IMAGE:-qmcgaw/gluetun:v3.39.1}"
 QBITTORRENT_IMAGE="${QBITTORRENT_IMAGE:-lscr.io/linuxserver/qbittorrent:latest}"
 QBT_DOCKER_MODS="${QBT_DOCKER_MODS:-ghcr.io/gabe565/linuxserver-mod-vuetorrent}"
-PF_SYNC_IMAGE="${PF_SYNC_IMAGE:-curlimages/curl:8.8.0}"
 SONARR_IMAGE="${SONARR_IMAGE:-lscr.io/linuxserver/sonarr:latest}"
 RADARR_IMAGE="${RADARR_IMAGE:-lscr.io/linuxserver/radarr:latest}"
 PROWLARR_IMAGE="${PROWLARR_IMAGE:-lscr.io/linuxserver/prowlarr:latest}"
@@ -83,7 +85,7 @@ SERVER_HOSTNAMES="${SERVER_HOSTNAMES:-}"
 DEFAULT_COUNTRY="${DEFAULT_COUNTRY:-Australia}"
 
 # Service/package lists used by uninstaller
-ALL_CONTAINERS="${ALL_CONTAINERS:-gluetun qbittorrent pf-sync sonarr radarr prowlarr bazarr flaresolverr jackett transmission lidarr readarr byparr}"
+ALL_CONTAINERS="${ALL_CONTAINERS:-gluetun qbittorrent sonarr radarr prowlarr bazarr flaresolverr jackett transmission lidarr readarr byparr}"
 ALL_NATIVE_SERVICES="${ALL_NATIVE_SERVICES:-sonarr radarr prowlarr bazarr jackett lidarr readarr qbittorrent transmission-daemon transmission-common byparr}"
 ALL_PACKAGES="${ALL_PACKAGES:-sonarr radarr prowlarr bazarr jackett lidarr readarr qbittorrent transmission-daemon transmission-common byparr}"
 


### PR DESCRIPTION
## Summary
- switch the compose template to Gluetun's native port forwarding flow with LAN firewall rules, resource limits, and validation helpers
- seed default environment variables for the new Gluetun options and add runtime checks for LAN access and port forwarding
- refresh documentation and helper aliases to remove the pf-sync container and describe the new workflow

## Testing
- bash -n arrstack.sh
- bash -n .aliasarr
- bash -n arrconf/userconf.defaults.sh

------
https://chatgpt.com/codex/tasks/task_e_68cc7635f29c83299bb38a099366e353